### PR TITLE
Increase `mongoDBPhaseCritical` alert generation time

### DIFF
--- a/charts/mongodb-alerts/README.md
+++ b/charts/mongodb-alerts/README.md
@@ -80,7 +80,7 @@ The following table lists the configurable parameters of the `mongodb-alerts` ch
 | form.alert.groups.database.rules.mongodbTooManyConnections.duration           |                                               | <code>"2m"</code>                                |
 | form.alert.groups.database.rules.mongodbTooManyConnections.severity           |                                               | <code>warning</code>                             |
 | form.alert.groups.database.rules.mongoDBPhaseCritical.enabled                 |                                               | <code>true</code>                                |
-| form.alert.groups.database.rules.mongoDBPhaseCritical.duration                |                                               | <code>"3m"</code>                                |
+| form.alert.groups.database.rules.mongoDBPhaseCritical.duration                |                                               | <code>"10m"</code>                               |
 | form.alert.groups.database.rules.mongoDBPhaseCritical.severity                |                                               | <code>warning</code>                             |
 | form.alert.groups.database.rules.mongoDBDown.enabled                          |                                               | <code>true</code>                                |
 | form.alert.groups.database.rules.mongoDBDown.duration                         |                                               | <code>"30s"</code>                               |

--- a/charts/mongodb-alerts/values.yaml
+++ b/charts/mongodb-alerts/values.yaml
@@ -66,7 +66,7 @@ form:
           # Sepcifies the alert configuration for database is in Critical phase, that means one or more of the nodes are down but the database read/write are not hampered.
           mongoDBPhaseCritical:
             enabled: true
-            duration: "3m"
+            duration: "10m"
             severity: warning
           # Sepcifies the alert configuration for database is in NotReady phase, that means the database is not accepting connections, read/write are hampered.
           mongoDBDown:


### PR DESCRIPTION
This pull request includes a change to the `charts/mongodb-alerts/values.yaml` file to adjust the alert configuration for the MongoDB critical phase. The most important change is:

* [`charts/mongodb-alerts/values.yaml`](diffhunk://#diff-419dffd1ea6f97b3c31a8ac16f93df38fac1d9b9503e8cc56664ca370152897cL69-R69): Increased the duration for the `mongoDBPhaseCritical` alert from "3m" to "10m".